### PR TITLE
Added Analog Camera Control

### DIFF
--- a/addons/goutte.camera.trackball/trackball_camera.gd
+++ b/addons/goutte.camera.trackball/trackball_camera.gd
@@ -184,16 +184,16 @@ func process_actions(delta):
 		var act_s:float
 		var act_i = -1 if action_invert else 1
 		if Input.is_action_pressed(action_up):
-			act_s = Input.get_action_strength(action_up) / 1000.0
+			act_s = Input.get_action_strength(action_up) * action_strength / 1000.0
 			add_inertia(Vector2(0, act_i * act_s))
 		if Input.is_action_pressed(action_down):
-			act_s = Input.get_action_strength(action_down) / 1000.0
+			act_s = Input.get_action_strength(action_down) * action_strength / 1000.0
 			add_inertia(Vector2(0, act_i * act_s * -1))
 		if Input.is_action_pressed(action_left):
-			act_s = Input.get_action_strength(action_left) / 1000.0
+			act_s = Input.get_action_strength(action_left) * action_strength / 1000.0
 			add_inertia(Vector2(act_i * act_s, 0))
 		if Input.is_action_pressed(action_right):
-			act_s = Input.get_action_strength(action_right) / 1000.0
+			act_s = Input.get_action_strength(action_right) * action_strength / 1000.0
 			add_inertia(Vector2(act_i * act_s * -1, 0))
 
 

--- a/addons/goutte.camera.trackball/trackball_camera.gd
+++ b/addons/goutte.camera.trackball/trackball_camera.gd
@@ -181,15 +181,19 @@ func process_joystick(delta):  # deprecated, use actions
 func process_actions(delta):
 	if action_enabled:
 		# Exported floats are truncated, so we use a bigger number
-		var act_s = action_strength / 1000.0
+		var act_s:float
 		var act_i = -1 if action_invert else 1
 		if Input.is_action_pressed(action_up):
+			act_s = Input.get_action_strength(action_up) / 1000.0
 			add_inertia(Vector2(0, act_i * act_s))
 		if Input.is_action_pressed(action_down):
+			act_s = Input.get_action_strength(action_down) / 1000.0
 			add_inertia(Vector2(0, act_i * act_s * -1))
 		if Input.is_action_pressed(action_left):
+			act_s = Input.get_action_strength(action_left) / 1000.0
 			add_inertia(Vector2(act_i * act_s, 0))
 		if Input.is_action_pressed(action_right):
+			act_s = Input.get_action_strength(action_right) / 1000.0
 			add_inertia(Vector2(act_i * act_s * -1, 0))
 
 


### PR DESCRIPTION
I've noticed that when you map a joystick as an action to rotate the camera, it will always rotate at the same rate no matter how far you push the joystick. With these commits you can rotate the camera with analog control without affecting normal button inputs. Since a button press will always result in a "1.0" as explained here: https://docs.godotengine.org/en/stable/classes/class_input.html#class-input-method-get-action-strength